### PR TITLE
fix: jesse app dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ routes(_Environment) ->
       #{prefix => "",
         security => false,
 	plugins => [
-		   {pre_request, nova_json_schemas, #{render_errrors => true}},
+		   {pre_request, nova_json_schemas, #{render_errors => true}},
                    {pre_request, nova_request_plugin, #{decode_json_body => true}}
 		   ],
 	routes => [

--- a/src/nova_json_schemas.app.src
+++ b/src/nova_json_schemas.app.src
@@ -4,7 +4,8 @@
   {registered, []},
   {applications,
    [kernel,
-    stdlib
+    stdlib,
+    jesse
    ]},
   {env,[]},
   {modules, []},


### PR DESCRIPTION
Our rebar3 release/tar didnt include jesse because there was no transient dependency to it. By having nova_json_schemas app.src include it we get it automatically. Its probably the right thing to do.

Also, a typo from the README caused our cut'n'paste code to also have a typo of `render_errors`. Probably not an intentional typo to keep people on their toes.

It would be nice if hex jesse was updated. The release there doesnt compile for us on otp 26. I dont know if the jesse maintainers can be poked to do that.