### PR TITLE
fix: Don't `io_lib:format` `error_type`

### DIFF
--- a/src/nova_json_schemas.erl
+++ b/src/nova_json_schemas.erl
@@ -143,7 +143,7 @@ render_error([{data_invalid, FieldInfo, Type, ActualValue, Field} | Tl]) ->
         #{
             error_context => schema_violation,
             field_info => FieldInfo,
-            error_type => io_lib:format("~p", [Type]),
+            error_type => Type,
             actual_value => ActualValue,
             expected_value => Field
         }


### PR DESCRIPTION
When returning this directly, it comes back as a string, but in the old code (with `io_lib:format/2`), the `error_type` comes back as a list of integers, which is not really super readable.

Old:

```
<<"[{\"error_type\":[109,105,115,115,105,110,103,95,114,101,113,117,105,114,101,100,95,112,114,111,112,101,114,116,121],\"error_context\":\"schema_violation\",\"field_info\":...
```

New:

```
<<"[{\"error_type\":\"missing_required_property\",\"error_context\":\"schema_violation\",\"field_info\":...
```