### PR TITLE
feat: add CI pipeline and eunit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  ci:
+    name: OTP ${{ matrix.otp }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        otp: ['27.2', '28.0']
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ matrix.otp }}
+          rebar3-version: '3.24'
+
+      - name: Restore rebar3 cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            _build
+            ~/.cache/rebar3
+          key: ${{ runner.os }}-otp-${{ matrix.otp }}-rebar3-${{ hashFiles('rebar.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-otp-${{ matrix.otp }}-rebar3-
+
+      - name: Compile
+        run: rebar3 compile
+
+      - name: EUnit
+        run: rebar3 eunit
+
+      - name: Dialyzer
+        run: rebar3 dialyzer
+
+      - name: XRef
+        run: rebar3 xref
+
+      - name: Format check
+        run: rebar3 fmt --check

--- a/rebar.config
+++ b/rebar.config
@@ -28,11 +28,16 @@
     {source_url, "https://github.com/novaframework/nova_json_schemas"}
 ]}.
 
+{xref_ignores, [
+    {nova_json_schemas, load_local_schemas, 0}
+]}.
+
 {erlfmt, [
     write,
     {files, [
         "rebar.config",
         "src/*.app.src",
-        "src/**/{*.erl, *.hrl}"
+        "src/**/{*.erl, *.hrl}",
+        "test/**/{*.erl, *.hrl}"
     ]}
 ]}.

--- a/src/nova_json_schemas.erl
+++ b/src/nova_json_schemas.erl
@@ -10,6 +10,13 @@
 
 -include_lib("kernel/include/logger.hrl").
 
+-ifdef(TEST).
+-export([
+    render_error/1,
+    validate_json/3
+]).
+-endif.
+
 %%--------------------------------------------------------------------
 %% @doc
 %% Load all local JSON schemas from the main application's

--- a/test/nova_json_schemas_tests.erl
+++ b/test/nova_json_schemas_tests.erl
@@ -1,0 +1,80 @@
+-module(nova_json_schemas_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%%--------------------------------------------------------------------
+%% render_error tests
+%%--------------------------------------------------------------------
+
+render_error_empty_test() ->
+    ?assertEqual([], nova_json_schemas:render_error([])).
+
+render_error_single_test() ->
+    Input = [{data_invalid, #{<<"type">> => <<"string">>}, wrong_type, 123, <<"name">>}],
+    [Error] = nova_json_schemas:render_error(Input),
+    ?assertEqual(schema_violation, maps:get(error_context, Error)),
+    ?assertEqual(wrong_type, maps:get(error_type, Error)),
+    ?assertEqual(123, maps:get(actual_value, Error)),
+    ?assertEqual(<<"name">>, maps:get(expected_value, Error)),
+    ?assertEqual(#{<<"type">> => <<"string">>}, maps:get(field_info, Error)).
+
+render_error_multiple_test() ->
+    Input = [
+        {data_invalid, #{}, wrong_type, 1, <<"a">>},
+        {data_invalid, #{}, missing_required_property, undefined, <<"b">>}
+    ],
+    Result = nova_json_schemas:render_error(Input),
+    ?assertEqual(2, length(Result)).
+
+%%--------------------------------------------------------------------
+%% validate_json tests
+%%--------------------------------------------------------------------
+
+validate_json_valid_test() ->
+    {ok, _} = application:ensure_all_started(jesse),
+    Schema = #{
+        <<"type">> => <<"object">>,
+        <<"properties">> => #{
+            <<"name">> => #{<<"type">> => <<"string">>}
+        },
+        <<"required">> => [<<"name">>]
+    },
+    jesse:add_schema("test_schema", Schema),
+    ?assertEqual(
+        ok, nova_json_schemas:validate_json("test_schema", #{<<"name">> => <<"alice">>}, [])
+    ).
+
+validate_json_invalid_test() ->
+    {ok, _} = application:ensure_all_started(jesse),
+    Schema = #{
+        <<"type">> => <<"object">>,
+        <<"properties">> => #{
+            <<"age">> => #{<<"type">> => <<"integer">>}
+        },
+        <<"required">> => [<<"age">>]
+    },
+    jesse:add_schema("test_schema_invalid", Schema),
+    {error, _} = nova_json_schemas:validate_json(
+        "test_schema_invalid", #{<<"age">> => <<"not_a_number">>}, []
+    ).
+
+%%--------------------------------------------------------------------
+%% plugin_info test
+%%--------------------------------------------------------------------
+
+plugin_info_test() ->
+    {ok, _} = application:ensure_all_started(nova_json_schemas),
+    Result = nova_json_schemas:plugin_info(),
+    ?assertMatch({_, _, _, _, _}, Result).
+
+%%--------------------------------------------------------------------
+%% pre_request passthrough tests
+%%--------------------------------------------------------------------
+
+pre_request_no_schema_no_body_test() ->
+    Req = #{has_body => false},
+    ?assertEqual({ok, Req}, nova_json_schemas:pre_request(Req, #{})).
+
+pre_request_missing_body_test() ->
+    Req = #{extra_state => #{json_schema => <<"some_schema">>}},
+    ?assertEqual({error, body_not_parsed}, nova_json_schemas:pre_request(Req, #{})).


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow running on OTP 27.2 and 28.0
- Add eunit tests for `render_error/1`, `validate_json/3`, `plugin_info/0`, and `pre_request/2` passthrough cases
- Fix xref warning by adding `load_local_schemas/0` to `xref_ignores` (valid public API for manual schema reloading)
- Add test file patterns to erlfmt config

## Test plan
- [x] All 8 eunit tests pass
- [x] Dialyzer clean
- [x] XRef clean
- [x] Formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)