### PR TITLE
fix: use git-derived version in app.src

### DIFF
--- a/src/nova_json_schemas.app.src
+++ b/src/nova_json_schemas.app.src
@@ -1,6 +1,6 @@
 {application, nova_json_schemas, [
     {description, "Validating JSON with schemas"},
-    {vsn, "0.1.1"},
+    {vsn, "git"},
     {registered, []},
     {applications, [
         kernel,


### PR DESCRIPTION
## Summary
- Change `{vsn, "0.1.1"}` to `{vsn, "git"}` so version is derived from git tags