### PR TITLE
feat: add Nova ecosystem metadata for Hex discovery

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -27,7 +27,10 @@
         {git, "https://github.com/Taure/rebar3_sbom.git", {branch, "feat/include-otp-components"}}}
 ]}.
 
-{hex, [{doc, #{provider => ex_doc}}]}.
+{hex, [
+    {doc, #{provider => ex_doc}},
+    {metadata, #{extra => #{<<"nova">> => <<"plugin">>}}}
+]}.
 
 {ex_doc, [
     {extras, [


### PR DESCRIPTION
## Summary
- Adds `extra` metadata to the Hex package config (`#{<<"nova">> => <<"plugin">>}`)
- Enables discovery via `extra:nova,plugin` Hex search queries
- Used by Nebula (Nova Package Store) to automatically find Nova ecosystem packages

## Test plan
- [ ] `rebar3 hex build` — verify metadata is included in tarball
- [ ] `rebar3 hex publish` — publish and confirm metadata on hex.pm