### PR TITLE
chore: disable audit, upgrade erlang-ci to v2.0.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,11 @@ permissions:
 
 jobs:
   ci:
-    uses: Taure/erlang-ci/.github/workflows/ci.yml@v1
-    permissions:
-      contents: write
-      pull-requests: write
+    uses: Taure/erlang-ci/.github/workflows/ci.yml@v2.0.9
     with:
       version-file: '.tool-versions'
       enable-ex-doc: true
-      enable-audit: true
+      enable-audit: false
       enable-sbom: true
       enable-sbom-scan: true
       enable-dependency-submission: true


### PR DESCRIPTION
Disable audit (use SBOM scan instead), upgrade erlang-ci, remove duplicate job-level permissions.